### PR TITLE
Fix destructor order/dependency issue

### DIFF
--- a/examples/controller/src/LogWindowGUI.cpp
+++ b/examples/controller/src/LogWindowGUI.cpp
@@ -28,27 +28,14 @@
 
 #include <sstream>
 
-LogWindowGUI::LogWindowGUI(QWidget* parent, RDMnetNetworkModel* model) : QDialog(parent), model_(model)
+LogWindowGUI::LogWindowGUI(QWidget* parent) : QDialog(parent)
 {
   ui.setupUi(this);
 
   connect(this, SIGNAL(appendText(const QString&)), this, SLOT(processAppendText(const QString&)), Qt::AutoConnection);
   connect(this, SIGNAL(clearText()), this, SLOT(processClearText()), Qt::AutoConnection);
 
-  if (model != NULL)
-  {
-    model->addCustomLogOutputStream(this);
-  }
-
   setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
-}
-
-LogWindowGUI::~LogWindowGUI()
-{
-  if (model_ != NULL)
-  {
-    model_->removeCustomLogOutputStream(this);
-  }
 }
 
 LogOutputStream& LogWindowGUI::operator<<(const std::string& str)

--- a/examples/controller/src/LogWindowGUI.h
+++ b/examples/controller/src/LogWindowGUI.h
@@ -40,8 +40,7 @@ class LogWindowGUI : public QDialog, public LogOutputStream
   Q_OBJECT
 
 public:
-  LogWindowGUI(QWidget* parent, RDMnetNetworkModel* model);
-  ~LogWindowGUI();
+  LogWindowGUI(QWidget* parent);
 
   // LogOutputStream implementation
   virtual LogOutputStream& operator<<(const std::string& str) override;
@@ -57,5 +56,4 @@ private slots:
 
 private:
   Ui::LogWindowGUI ui;
-  RDMnetNetworkModel* model_;
 };

--- a/examples/controller/src/RDMnetControllerGUI.cpp
+++ b/examples/controller/src/RDMnetControllerGUI.cpp
@@ -44,19 +44,29 @@ END_INCLUDE_QT_HEADERS()
 
 RDMnetControllerGUI::~RDMnetControllerGUI()
 {
-  if (main_network_model_ != NULL)
+  if (net_details_proxy_ != nullptr)
   {
-    delete main_network_model_;
+    delete net_details_proxy_;
   }
 
-  if (simple_net_proxy_ != NULL)
+  if (simple_net_proxy_ != nullptr)
   {
     delete simple_net_proxy_;
   }
 
-  if (net_details_proxy_ != NULL)
+  if (main_network_model_ != nullptr)
   {
-    delete net_details_proxy_;
+    delete main_network_model_;
+  }
+
+  if (rdmnet_library_ != nullptr)
+  {
+    delete rdmnet_library_;
+  }
+
+  if (log_ != nullptr)
+  {
+    delete log_;
   }
 }
 
@@ -284,11 +294,13 @@ void RDMnetControllerGUI::openLogWindowDialog()
   {
     if (main_network_model_->getNumberOfCustomLogOutputStreams() == 0)
     {
-      LogWindowGUI* logWindowDialog = new LogWindowGUI(this, main_network_model_);
+      LogWindowGUI* logWindowDialog = new LogWindowGUI(this);
       logWindowDialog->setAttribute(Qt::WA_DeleteOnClose);
       logWindowDialog->setWindowTitle(tr("Log Window"));
       logWindowDialog->resize(QSize(static_cast<int>(logWindowDialog->width() * 1.2), logWindowDialog->height()));
       logWindowDialog->show();
+
+      log_->addCustomOutputStream(logWindowDialog);
     }
   }
 }


### PR DESCRIPTION
LogWindowGUI was depending on the main network model which was sometimes destroyed when accessed, causing a crash. LogWindowGUI no longer depends on it, and it is up to the code using LogWindowGUI to connect it to output streams. This is a better design and fixes the crash.