### PR TITLE
Sleep crash and infinite loop fix

### DIFF
--- a/examples/broker/src/broker_shell.cpp
+++ b/examples/broker/src/broker_shell.cpp
@@ -138,6 +138,8 @@ void BrokerShell::Run(RDMnet::BrokerLog* log, RDMnet::BrokerSocketManager* sock_
     }
     else if (restart_requested_)
     {
+      restart_requested_ = false; // Prevent broker from restarting infinitely many times
+
       broker.GetSettings(broker_settings);
       broker.Shutdown();
 

--- a/examples/broker/src/broker_shell.h
+++ b/examples/broker/src/broker_shell.h
@@ -31,6 +31,7 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <atomic>
 #include "lwpa/inet.h"
 #include "lwpa/log.h"
 #include "rdmnet/broker.h"
@@ -74,7 +75,7 @@ private:
   } initial_data_;
 
   RDMnet::BrokerLog* log_{nullptr};
-  bool restart_requested_{false};
+  std::atomic<bool> restart_requested_{false};
   bool shutdown_requested_{false};
   std::string new_scope_;
 };

--- a/src/rdmnet/discovery/bonjour.c
+++ b/src/rdmnet/discovery/bonjour.c
@@ -571,6 +571,7 @@ void rdmnetdisc_unregister_broker(rdmnet_registered_broker_t handle)
     /* Since the broker only cares about scopes while it is running, shut down any outstanding
      * queries for that scope.*/
     rdmnetdisc_stop_monitoring(handle->scope_monitor_handle);
+    handle->scope_monitor_handle = NULL;
 
     /*Reset the state*/
     disc_state.broker_ref.state = kBrokerStateNotRegistered;


### PR DESCRIPTION
Fixes problems where when the host machine is put into sleep mode while the Broker is running, the broker would crash. After the crash was fixed, the broker would enter an infinite reboot loop. Both of these problems have been fixed.