### PR TITLE
Create startup/shutdown functions

### DIFF
--- a/examples/controller/src/RDMnetControllerGUI.h
+++ b/examples/controller/src/RDMnetControllerGUI.h
@@ -51,11 +51,11 @@ class RDMnetControllerGUI : public QMainWindow, public IHandlesBrokerStaticAdd
 public:
   static RDMnetControllerGUI* makeRDMnetControllerGUI();
 
-  ~RDMnetControllerGUI();
-
   virtual void handleAddBrokerByIP(QString scope, const LwpaSockaddr& addr);
 
 public slots:
+
+  void Shutdown();
 
   void networkTreeViewSelectionChanged(const QItemSelection& selected, const QItemSelection& deselected);
   void addScopeTriggered();
@@ -88,8 +88,8 @@ private:
   RDMnetNetworkModel* main_network_model_{nullptr};
   SimpleNetworkProxyModel* simple_net_proxy_{nullptr};
   NetworkDetailsProxyModel* net_details_proxy_{nullptr};
-  ControllerLog* log_{nullptr};
-  RDMnetLibWrapper* rdmnet_library_{nullptr};
+  std::unique_ptr<ControllerLog> log_;
+  std::unique_ptr<RDMnetLibWrapper> rdmnet_library_;
   BrokerItem* currently_selected_broker_item_{nullptr};
   RDMnetNetworkItem* currently_selected_network_item_{nullptr};
 };

--- a/examples/controller/src/RDMnetLibWrapper.cpp
+++ b/examples/controller/src/RDMnetLibWrapper.cpp
@@ -155,6 +155,7 @@ void RDMnetLibWrapper::Shutdown()
     running_ = false;
     notify_ = nullptr;
     my_cid_ = kLwpaNullUuid;
+    log_ = nullptr;
   }
 }
 

--- a/examples/controller/src/RDMnetNetworkModel.h
+++ b/examples/controller/src/RDMnetNetworkModel.h
@@ -99,12 +99,15 @@ protected slots:
   void removeAllBrokers();
   void activateFeature(RDMnetNetworkItem* device, SupportedDeviceFeature feature);
 
-public:
-  void InitRDMnet();
-  void ShutdownRDMnet();
+protected:
+  RDMnetNetworkModel(RDMnetLibInterface* library, ControllerLog* log);
 
+public:
   static RDMnetNetworkModel* makeRDMnetNetworkModel(RDMnetLibInterface* library, ControllerLog* log);
   static RDMnetNetworkModel* makeTestModel();
+
+  RDMnetNetworkModel() = delete;
+  void Shutdown();
 
   void searchingItemRevealed(SearchingStatusItem* searchItem);
 
@@ -241,8 +244,4 @@ protected:
 
   void removeScopeSlotItemsInRange(RDMnetNetworkItem* parent, std::vector<class PropertyItem*>* properties,
                                    uint16_t firstSlot, uint16_t lastSlot);
-
-public:
-  RDMnetNetworkModel(RDMnetLibInterface* library, ControllerLog* log);
-  ~RDMnetNetworkModel();
 };

--- a/examples/controller/src/main.cpp
+++ b/examples/controller/src/main.cpp
@@ -39,9 +39,11 @@ int main(int argc, char* argv[])
   QApplication a(argc, argv);
   RDMnetControllerGUI* w = RDMnetControllerGUI::makeRDMnetControllerGUI();
 
+  a.connect(&a, &QApplication::lastWindowClosed, w, &RDMnetControllerGUI::Shutdown);
+
   w->show();
   retVal = a.exec();
 
-  delete w;
+  delete w; // w->deleteLater() won't work because a's event loop has ended.
   return retVal;
 }


### PR DESCRIPTION
...also use unique_ptr for a couple objects. main_network_model_, simple_net_proxy_, and net_details_proxy_ in RDMnetControllerGUI cannot use unique_ptrs because the RDMnetControllerGUI object is destroyed after the Qt event loop ends (see main.cpp), so deleteLater() should not be called from unique_ptr's deleter. It is called manually instead, in RDMnetControllerGUI::Shutdown, before the event loop ends.

Resolves https://jira.etcconnect.com/browse/RDMNET-113.