### PR TITLE
Bring BrokerSocketManager into the core Broker library

### DIFF
--- a/examples/broker/CMakeLists.txt
+++ b/examples/broker/CMakeLists.txt
@@ -15,8 +15,6 @@ if(WIN32)
     src/windows/main.cpp
     src/windows/win_broker_log.h
     src/windows/win_broker_log.cpp
-    src/windows/win_socket_manager.h
-    src/windows/win_socket_manager.cpp
   )
   target_compile_definitions(${BROKER_TARGET} PRIVATE UNICODE _UNICODE)
   if(DEFINED DNS_SD_DLL)
@@ -32,8 +30,6 @@ elseif(APPLE)
     src/macos/main.cpp
     src/macos/macos_broker_log.h
     src/macos/macos_broker_log.cpp
-    src/macos/macos_socket_manager.h
-    src/macos/macos_socket_manager.cpp
   )
   target_link_libraries(${BROKER_TARGET} PRIVATE pthread)
 elseif(UNIX)
@@ -41,8 +37,6 @@ elseif(UNIX)
     src/linux/main.cpp
     src/linux/linux_broker_log.h
     src/linux/linux_broker_log.cpp
-    src/linux/linux_socket_manager.h
-    src/linux/linux_socket_manager.cpp
   )
   target_link_libraries(${BROKER_TARGET} PRIVATE pthread)
 endif()

--- a/examples/broker/src/broker_shell.cpp
+++ b/examples/broker/src/broker_shell.cpp
@@ -50,7 +50,7 @@ void BrokerShell::AsyncShutdown()
   shutdown_requested_ = true;
 }
 
-void BrokerShell::ApplySettingsChanges(RDMnet::BrokerSettings& settings, std::vector<EtcPalIpAddr>& new_addrs)
+void BrokerShell::ApplySettingsChanges(rdmnet::BrokerSettings& settings, std::vector<EtcPalIpAddr>& new_addrs)
 {
   new_addrs = GetInterfacesToListen();
 
@@ -98,14 +98,14 @@ std::vector<EtcPalIpAddr> BrokerShell::ConvertMacsToInterfaces(const std::vector
   return to_return;
 }
 
-void BrokerShell::Run(RDMnet::BrokerLog* log)
+void BrokerShell::Run(rdmnet::BrokerLog* log)
 {
   PrintWarningMessage();
 
   log_ = log;
   log_->Startup(initial_data_.log_mask);
 
-  RDMnet::BrokerSettings broker_settings(0x6574);
+  rdmnet::BrokerSettings broker_settings(0x6574);
   broker_settings.disc_attributes.scope = initial_data_.scope;
 
   std::vector<EtcPalIpAddr> ifaces = GetInterfacesToListen();
@@ -116,7 +116,7 @@ void BrokerShell::Run(RDMnet::BrokerLog* log)
   broker_settings.disc_attributes.dns_service_instance_name = "UNIQUE NAME";
   broker_settings.disc_attributes.dns_model = "E1.33 Broker Prototype";
 
-  RDMnet::Broker broker(log, this);
+  rdmnet::Broker broker(log, this);
   broker.Startup(broker_settings, initial_data_.port, ifaces);
 
   // We want this to run forever if a console

--- a/examples/broker/src/broker_shell.cpp
+++ b/examples/broker/src/broker_shell.cpp
@@ -77,7 +77,7 @@ std::vector<EtcPalIpAddr> BrokerShell::GetInterfacesToListen()
   }
 }
 
-std::vector<EtcPalIpAddr> BrokerShell::ConvertMacsToInterfaces(const std::vector<MacAddr>& macs)
+std::vector<EtcPalIpAddr> BrokerShell::ConvertMacsToInterfaces(const std::vector<MacAddress>& macs)
 {
   std::vector<EtcPalIpAddr> to_return;
 
@@ -98,7 +98,7 @@ std::vector<EtcPalIpAddr> BrokerShell::ConvertMacsToInterfaces(const std::vector
   return to_return;
 }
 
-void BrokerShell::Run(RDMnet::BrokerLog* log, RDMnet::BrokerSocketManager* sock_mgr)
+void BrokerShell::Run(RDMnet::BrokerLog* log)
 {
   PrintWarningMessage();
 
@@ -116,7 +116,7 @@ void BrokerShell::Run(RDMnet::BrokerLog* log, RDMnet::BrokerSocketManager* sock_
   broker_settings.disc_attributes.dns_service_instance_name = "UNIQUE NAME";
   broker_settings.disc_attributes.dns_model = "E1.33 Broker Prototype";
 
-  RDMnet::Broker broker(log, sock_mgr, this);
+  RDMnet::Broker broker(log, this);
   broker.Startup(broker_settings, initial_data_.port, ifaces);
 
   // We want this to run forever if a console
@@ -149,7 +149,7 @@ void BrokerShell::Run(RDMnet::BrokerLog* log, RDMnet::BrokerSocketManager* sock_
 
 void BrokerShell::PrintVersion()
 {
-  std::cout << "ETC Prototype RDMnet Broker\n";
+  std::cout << "ETC Example RDMnet Broker\n";
   std::cout << "Version " << RDMNET_VERSION_STRING << "\n\n";
   std::cout << RDMNET_VERSION_COPYRIGHT << "\n";
   std::cout << "License: Apache License v2.0 <http://www.apache.org/licenses/LICENSE-2.0>\n";

--- a/examples/broker/src/broker_shell.h
+++ b/examples/broker/src/broker_shell.h
@@ -31,12 +31,12 @@
 // BrokerShell : Platform-neutral wrapper around the Broker library from a generic console
 // application. Instantiates and drives the Broker library.
 
-class BrokerShell : public RDMnet::BrokerNotify
+class BrokerShell : public rdmnet::BrokerNotify
 {
 public:
   typedef std::array<uint8_t, ETCPAL_NETINTINFO_MAC_LEN> MacAddress;
 
-  void Run(RDMnet::BrokerLog* log);
+  void Run(rdmnet::BrokerLog* log);
   static void PrintVersion();
 
   // Options to set from the command line; must be set BEFORE Run() is called.
@@ -55,7 +55,7 @@ private:
 
   std::vector<EtcPalIpAddr> GetInterfacesToListen();
   std::vector<EtcPalIpAddr> ConvertMacsToInterfaces(const std::vector<MacAddress>& macs);
-  void ApplySettingsChanges(RDMnet::BrokerSettings& settings, std::vector<EtcPalIpAddr>& new_addrs);
+  void ApplySettingsChanges(rdmnet::BrokerSettings& settings, std::vector<EtcPalIpAddr>& new_addrs);
 
   struct InitialData
   {
@@ -66,7 +66,7 @@ private:
     int log_mask{ETCPAL_LOG_UPTO(ETCPAL_LOG_INFO)};
   } initial_data_;
 
-  RDMnet::BrokerLog* log_{nullptr};
+  rdmnet::BrokerLog* log_{nullptr};
   std::atomic<bool> restart_requested_{false};
   bool shutdown_requested_{false};
   std::string new_scope_;

--- a/examples/broker/src/broker_shell.h
+++ b/examples/broker/src/broker_shell.h
@@ -34,15 +34,15 @@
 class BrokerShell : public RDMnet::BrokerNotify
 {
 public:
-  typedef std::array<uint8_t, ETCPAL_NETINTINFO_MAC_LEN> MacAddr;
+  typedef std::array<uint8_t, ETCPAL_NETINTINFO_MAC_LEN> MacAddress;
 
-  void Run(RDMnet::BrokerLog* log, RDMnet::BrokerSocketManager* socket_mgr);
+  void Run(RDMnet::BrokerLog* log);
   static void PrintVersion();
 
   // Options to set from the command line; must be set BEFORE Run() is called.
   void SetInitialScope(const std::string& scope) { initial_data_.scope = scope; }
   void SetInitialIfaceList(const std::vector<EtcPalIpAddr>& ifaces) { initial_data_.ifaces = ifaces; }
-  void SetInitialMacList(const std::vector<MacAddr>& macs) { initial_data_.macs = macs; }
+  void SetInitialMacList(const std::vector<MacAddress>& macs) { initial_data_.macs = macs; }
   void SetInitialPort(uint16_t port) { initial_data_.port = port; }
   void SetInitialLogLevel(int level) { initial_data_.log_mask = ETCPAL_LOG_UPTO(level); }
 
@@ -54,14 +54,14 @@ private:
   void PrintWarningMessage();
 
   std::vector<EtcPalIpAddr> GetInterfacesToListen();
-  std::vector<EtcPalIpAddr> ConvertMacsToInterfaces(const std::vector<MacAddr>& macs);
+  std::vector<EtcPalIpAddr> ConvertMacsToInterfaces(const std::vector<MacAddress>& macs);
   void ApplySettingsChanges(RDMnet::BrokerSettings& settings, std::vector<EtcPalIpAddr>& new_addrs);
 
   struct InitialData
   {
     std::string scope{E133_DEFAULT_SCOPE};
     std::vector<EtcPalIpAddr> ifaces;
-    std::vector<MacAddr> macs;
+    std::vector<MacAddress> macs;
     uint16_t port{0};
     int log_mask{ETCPAL_LOG_UPTO(ETCPAL_LOG_INFO)};
   } initial_data_;

--- a/examples/broker/src/linux/linux_broker_log.cpp
+++ b/examples/broker/src/linux/linux_broker_log.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <cstdarg>
 
-LinuxBrokerLog::LinuxBrokerLog(const std::string& file_name) : RDMnet::BrokerLog()
+LinuxBrokerLog::LinuxBrokerLog(const std::string& file_name) : rdmnet::BrokerLog()
 {
   file_.open(file_name.c_str(), std::fstream::out);
   if (file_.fail())

--- a/examples/broker/src/linux/linux_broker_log.h
+++ b/examples/broker/src/linux/linux_broker_log.h
@@ -29,7 +29,7 @@
 #include "etcpal/lock.h"
 #include "rdmnet/broker/log.h"
 
-class LinuxBrokerLog : public RDMnet::BrokerLog
+class LinuxBrokerLog : public rdmnet::BrokerLog
 {
 public:
   LinuxBrokerLog(const std::string& file_name);

--- a/examples/broker/src/linux/main.cpp
+++ b/examples/broker/src/linux/main.cpp
@@ -25,7 +25,6 @@
 #include <map>
 #include <unistd.h>
 #include "broker_shell.h"
-#include "linux_socket_manager.h"
 #include "linux_broker_log.h"
 
 // Print the command-line usage details.
@@ -93,7 +92,7 @@ bool ParseAndSetIfaceList(char* iface_list_str, BrokerShell& broker_shell)
 }
 
 // Given a pointer to a string, parses out a mac addr
-void ParseMac(char* s, BrokerShell::MacAddr& mac_buf)
+void ParseMac(char* s, BrokerShell::MacAddress& mac_buf)
 {
   char* p = s;
 
@@ -107,14 +106,14 @@ void ParseMac(char* s, BrokerShell::MacAddr& mac_buf)
 // Parse the --macs=MAC_LIST command line option and transfer it to the BrokerShell instance.
 bool ParseAndSetMacList(char* mac_list_str, BrokerShell& broker_shell)
 {
-  std::vector<BrokerShell::MacAddr> macs;
+  std::vector<BrokerShell::MacAddress> macs;
 
   if (strlen(mac_list_str) != 0)
   {
     char* context;
     for (char* p = strtok_r(mac_list_str, ",", &context); p != NULL; p = strtok_r(NULL, ",", &context))
     {
-      BrokerShell::MacAddr mac_buf;
+      BrokerShell::MacAddress mac_buf;
       ParseMac(p, mac_buf);
       macs.push_back(mac_buf);
     }
@@ -315,9 +314,8 @@ int main(int argc, char* argv[])
     sigaction(SIGINT, &sigint_handler, NULL);
 
     // Startup and run the Broker.
-    LinuxBrokerSocketManager socket_mgr;
     LinuxBrokerLog log("RDMnetBroker.log");
-    broker_shell.Run(&log, &socket_mgr);
+    broker_shell.Run(&log);
 
     // Unregister/cleanup the network change detection. (Disabled for now)
     // CancelMibChangeNotify2(change_notif_handle);

--- a/examples/broker/src/macos/macos_broker_log.cpp
+++ b/examples/broker/src/macos/macos_broker_log.cpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <cstdarg>
 
-MacBrokerLog::MacBrokerLog(const std::string& file_name) : RDMnet::BrokerLog()
+MacBrokerLog::MacBrokerLog(const std::string& file_name) : rdmnet::BrokerLog()
 {
   file_.open(file_name.c_str(), std::fstream::out);
   if (file_.fail())

--- a/examples/broker/src/macos/macos_broker_log.h
+++ b/examples/broker/src/macos/macos_broker_log.h
@@ -29,7 +29,7 @@
 #include "etcpal/lock.h"
 #include "rdmnet/broker/log.h"
 
-class MacBrokerLog : public RDMnet::BrokerLog
+class MacBrokerLog : public rdmnet::BrokerLog
 {
 public:
   MacBrokerLog(const std::string& file_name);

--- a/examples/broker/src/macos/main.cpp
+++ b/examples/broker/src/macos/main.cpp
@@ -25,7 +25,6 @@
 #include <map>
 #include <unistd.h>
 #include "broker_shell.h"
-#include "macos_socket_manager.h"
 #include "macos_broker_log.h"
 
 // Print the command-line usage details.
@@ -93,7 +92,7 @@ bool ParseAndSetIfaceList(char* iface_list_str, BrokerShell& broker_shell)
 }
 
 // Given a pointer to a string, parses out a mac addr
-void ParseMac(char* s, BrokerShell::MacAddr& mac_buf)
+void ParseMac(char* s, BrokerShell::MacAddress& mac_buf)
 {
   char* p = s;
 
@@ -107,14 +106,14 @@ void ParseMac(char* s, BrokerShell::MacAddr& mac_buf)
 // Parse the --macs=MAC_LIST command line option and transfer it to the BrokerShell instance.
 bool ParseAndSetMacList(char* mac_list_str, BrokerShell& broker_shell)
 {
-  std::vector<BrokerShell::MacAddr> macs;
+  std::vector<BrokerShell::MacAddress> macs;
 
   if (strlen(mac_list_str) != 0)
   {
     char* context;
     for (char* p = strtok_r(mac_list_str, ",", &context); p != NULL; p = strtok_r(NULL, ",", &context))
     {
-      BrokerShell::MacAddr mac_buf;
+      BrokerShell::MacAddress mac_buf;
       ParseMac(p, mac_buf);
       macs.push_back(mac_buf);
     }
@@ -315,9 +314,8 @@ int main(int argc, char* argv[])
     sigaction(SIGINT, &sigint_handler, NULL);
 
     // Startup and run the Broker.
-    MacBrokerSocketManager socket_mgr;
     MacBrokerLog log("RDMnetBroker.log");
-    broker_shell.Run(&log, &socket_mgr);
+    broker_shell.Run(&log);
 
     // Unregister/cleanup the network change detection. (Disabled for now)
     // CancelMibChangeNotify2(change_notif_handle);

--- a/examples/broker/src/windows/main.cpp
+++ b/examples/broker/src/windows/main.cpp
@@ -26,7 +26,6 @@
 #include <iostream>
 #include <map>
 #include "broker_shell.h"
-#include "win_socket_manager.h"
 #include "win_broker_log.h"
 
 // Print the command-line usage details.
@@ -115,7 +114,7 @@ bool ParseAndSetIfaceList(const LPWSTR iface_list_str, BrokerShell& broker_shell
 }
 
 // Given a pointer to a string, parses out a mac addr
-void ParseMac(WCHAR* s, BrokerShell::MacAddr& mac_buf)
+void ParseMac(WCHAR* s, BrokerShell::MacAddress& mac_buf)
 {
   WCHAR* p = s;
 
@@ -129,14 +128,14 @@ void ParseMac(WCHAR* s, BrokerShell::MacAddr& mac_buf)
 // Parse the --macs=MAC_LIST command line option and transfer it to the BrokerShell instance.
 bool ParseAndSetMacList(const LPWSTR mac_list_str, BrokerShell& broker_shell)
 {
-  std::vector<BrokerShell::MacAddr> macs;
+  std::vector<BrokerShell::MacAddress> macs;
 
   if (wcslen(mac_list_str) != 0)
   {
     WCHAR* context;
     for (WCHAR* p = wcstok_s(mac_list_str, L",", &context); p != NULL; p = wcstok_s(NULL, L",", &context))
     {
-      BrokerShell::MacAddr mac_buf;
+      BrokerShell::MacAddress mac_buf;
       ParseMac(p, mac_buf);
       macs.push_back(mac_buf);
     }
@@ -333,9 +332,8 @@ int wmain(int argc, wchar_t* argv[])
     SetConsoleCtrlHandler(ConsoleSignalHandler, TRUE);
 
     // Startup and run the Broker.
-    WinBrokerSocketManager socket_mgr;
     WindowsBrokerLog log("RDMnetBroker.log");
-    broker_shell.Run(&log, &socket_mgr);
+    broker_shell.Run(&log);
 
     // Unregister/cleanup the network change detection.
     CancelMibChangeNotify2(change_notif_handle);

--- a/examples/broker/src/windows/win_broker_log.cpp
+++ b/examples/broker/src/windows/win_broker_log.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <cstdarg>
 
-WindowsBrokerLog::WindowsBrokerLog(const std::string& file_name) : RDMnet::BrokerLog(), utcoffset_(0)
+WindowsBrokerLog::WindowsBrokerLog(const std::string& file_name) : rdmnet::BrokerLog(), utcoffset_(0)
 {
   file_.open(file_name.c_str(), std::fstream::out);
   if (file_.fail())

--- a/examples/broker/src/windows/win_broker_log.h
+++ b/examples/broker/src/windows/win_broker_log.h
@@ -31,7 +31,7 @@
 #include "etcpal/lock.h"
 #include "rdmnet/broker/log.h"
 
-class WindowsBrokerLog : public RDMnet::BrokerLog
+class WindowsBrokerLog : public rdmnet::BrokerLog
 {
 public:
   WindowsBrokerLog(const std::string& file_name);

--- a/include/rdmnet/broker.h
+++ b/include/rdmnet/broker.h
@@ -41,7 +41,7 @@ class BrokerCore;
 ///
 
 /// A namespace to contain the public Broker classes
-namespace RDMnet
+namespace rdmnet
 {
 /// Settings for the Broker's DNS Discovery functionality.
 struct BrokerDiscoveryAttributes
@@ -105,10 +105,6 @@ struct BrokerSettings
   /// supported to reject the connection request.
   unsigned int max_reject_connections{1000};
 
-  /// MODIFY FOR DEBUG PURPOSES ONLY: each read thread can support this many sockets, up to the
-  /// maximum allowed by your platform's socket implementation.
-  // unsigned int max_socket_per_read_thread{ETCPAL_SOCKET_MAX_POLL_SIZE};
-
   BrokerSettings() {}
   BrokerSettings(const RdmUid& static_uid) { SetStaticUid(static_uid); }
   BrokerSettings(uint16_t rdm_manu_id) { SetDynamicUid(rdm_manu_id); }
@@ -145,7 +141,7 @@ private:
   std::unique_ptr<BrokerCore> core_;
 };
 
-};  // namespace RDMnet
+};  // namespace rdmnet
 
 /// @}
 

--- a/include/rdmnet/broker.h
+++ b/include/rdmnet/broker.h
@@ -32,7 +32,6 @@
 #include "rdm/uid.h"
 #include "rdmnet/defs.h"
 #include "rdmnet/broker/log.h"
-#include "rdmnet/broker/socket_manager.h"
 
 class BrokerCore;
 
@@ -133,7 +132,7 @@ public:
 class Broker
 {
 public:
-  Broker(BrokerLog* log, BrokerSocketManager* socket_manager, BrokerNotify* notify);
+  Broker(BrokerLog* log, BrokerNotify* notify);
   virtual ~Broker();
 
   bool Startup(const BrokerSettings& settings, uint16_t listen_port, std::vector<EtcPalIpAddr>& listen_addrs);

--- a/include/rdmnet/broker/log.h
+++ b/include/rdmnet/broker/log.h
@@ -28,7 +28,7 @@
 #include "etcpal/log.h"
 #include "etcpal/thread.h"
 
-namespace RDMnet
+namespace rdmnet
 {
 /// \brief A class for logging messages from the %Broker.
 class BrokerLog
@@ -59,6 +59,6 @@ protected:
   bool keep_running_{false};
 };
 
-};  // namespace RDMnet
+};  // namespace rdmnet
 
 #endif  // _RDMNET_BROKER_LOG_H_

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,9 @@ endif()
 rdmnet_add_dependency(EtcPal ETCPAL_DIR)
 rdmnet_add_dependency(RDM RDM_DIR)
 
-set_target_properties(EtcPalMock PROPERTIES FOLDER dependencies)
+if(TARGET EtcPalMock)
+  set_target_properties(EtcPalMock PROPERTIES FOLDER dependencies)
+endif()
 
 ################################## Libraries ##################################
 

--- a/src/rdmnet/CMakeLists.txt
+++ b/src/rdmnet/CMakeLists.txt
@@ -147,35 +147,48 @@ target_link_libraries(RDMnet PRIVATE RDMnetDiscovery dnssd)
 
 #################################### Broker ###################################
 
-add_library(Broker
-  # Broker public headers
-  ${RDMNET_INCLUDE}/rdmnet/broker.h
-  ${RDMNET_INCLUDE}/rdmnet/broker/log.h
-  ${RDMNET_INCLUDE}/rdmnet/broker/socket_manager.h
+if(WIN32 OR APPLE OR UNIX)
+  add_library(Broker
+    # Broker public headers
+    ${RDMNET_INCLUDE}/rdmnet/broker.h
+    ${RDMNET_INCLUDE}/rdmnet/broker/log.h
+    # ${RDMNET_INCLUDE}/rdmnet/broker/socket_manager.h
 
-  broker/broker_core.h
-  broker/broker_core.cpp
-  broker/broker_client.h
-  broker/broker_client.cpp
-  broker/broker_discovery.h
-  broker/broker_discovery.cpp
-  broker/broker_log.cpp
-  broker/broker_responder.h
-  broker/broker_responder.cpp
-  broker/broker_threads.h
-  broker/broker_threads.cpp
-  broker/broker_uid_manager.h
-  broker/broker_uid_manager.cpp
-  broker/broker_util.h
-  broker/broker_util.cpp
-  broker/rdmnet_conn_wrapper.h
-  broker/rdmnet_conn_wrapper.cpp
-)
-target_include_directories(Broker PUBLIC ${RDMNET_INCLUDE})
-target_link_libraries(Broker PUBLIC RDMnet)
-set_target_properties(Broker PROPERTIES CXX_STANDARD 14)
+    broker/broker_core.h
+    broker/broker_core.cpp
+    broker/broker_client.h
+    broker/broker_client.cpp
+    broker/broker_discovery.h
+    broker/broker_discovery.cpp
+    broker/broker_log.cpp
+    broker/broker_responder.h
+    broker/broker_responder.cpp
+    broker/broker_socket_manager.h
+    broker/broker_threads.h
+    broker/broker_threads.cpp
+    broker/broker_uid_manager.h
+    broker/broker_uid_manager.cpp
+    broker/broker_util.h
+    broker/broker_util.cpp
+    broker/rdmnet_conn_wrapper.h
+    broker/rdmnet_conn_wrapper.cpp
+  )
+
+  if(WIN32)
+    target_sources(Broker PRIVATE
+      broker/windows/win_socket_manager.h
+      broker/windows/win_socket_manager.cpp
+    )
+  endif()
+
+  target_include_directories(Broker PUBLIC ${RDMNET_INCLUDE} broker)
+  target_link_libraries(Broker PUBLIC RDMnet)
+  set_target_properties(Broker PROPERTIES CXX_STANDARD 14)
+  install(TARGETS Broker ARCHIVE DESTINATION lib)
+
+
+endif()
 
 # Installation
 install(TARGETS RDMnet ARCHIVE DESTINATION lib)
-install(TARGETS Broker ARCHIVE DESTINATION lib)
 install(DIRECTORY ${RDMNET_ROOT}/include/rdmnet DESTINATION include FILES_MATCHING PATTERN "*.h")

--- a/src/rdmnet/CMakeLists.txt
+++ b/src/rdmnet/CMakeLists.txt
@@ -179,6 +179,16 @@ if(WIN32 OR APPLE OR UNIX)
       broker/windows/win_socket_manager.h
       broker/windows/win_socket_manager.cpp
     )
+  elseif(APPLE)
+    target_sources(Broker PRIVATE
+      broker/macos/macos_socket_manager.h
+      broker/macos/macos_socket_manager.cpp
+    )
+  elseif(UNIX)
+    target_sources(Broker PRIVATE
+      broker/linux/linux_socket_manager.h
+      broker/linux/linux_socket_manager.cpp
+    )
   endif()
 
   target_include_directories(Broker PUBLIC ${RDMNET_INCLUDE} broker)

--- a/src/rdmnet/broker/broker_core.cpp
+++ b/src/rdmnet/broker/broker_core.cpp
@@ -33,9 +33,8 @@
 
 /*************************** Function definitions ****************************/
 
-RDMnet::Broker::Broker(BrokerLog* log, BrokerSocketManager* socket_manager, BrokerNotify* notify)
-    : core_(std::make_unique<BrokerCore>(log, socket_manager, notify,
-                                         std::unique_ptr<RdmnetConnInterface>(new RdmnetConnWrapper)))
+RDMnet::Broker::Broker(BrokerLog* log, BrokerNotify* notify)
+    : core_(std::make_unique<BrokerCore>(log, notify, std::unique_ptr<RdmnetConnInterface>(new RdmnetConnWrapper)))
 {
 }
 
@@ -79,14 +78,13 @@ void RDMnet::Broker::GetSettings(BrokerSettings& settings) const
 // BrokerCore: Private implementation of Broker functionality.
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-BrokerCore::BrokerCore(RDMnet::BrokerLog* log, RDMnet::BrokerSocketManager* socket_manager,
-                       RDMnet::BrokerNotify* notify, std::unique_ptr<RdmnetConnInterface> conn)
+BrokerCore::BrokerCore(RDMnet::BrokerLog* log, RDMnet::BrokerNotify* notify, std::unique_ptr<RdmnetConnInterface> conn)
     : RdmnetConnNotify()
     , ListenThreadNotify()
     , ClientServiceThreadNotify()
     , BrokerDiscoveryManagerNotify()
     , log_(log)
-    , socket_manager_(socket_manager)
+    , socket_manager_(CreateBrokerSocketManager())
     , notify_(notify)
     , conn_interface_(std::move(conn))
     , service_thread_(1)
@@ -152,8 +150,8 @@ bool BrokerCore::Startup(const RDMnet::BrokerSettings& settings, uint16_t listen
 
     disc_.RegisterBroker(settings_.disc_attributes, settings_.cid, listen_addrs_, listen_port_);
 
-    log_->Log(ETCPAL_LOG_INFO, "%s Prototype RDMnet Broker Version %s",
-              settings.disc_attributes.dns_manufacturer.c_str(), RDMNET_VERSION_STRING);
+    log_->Log(ETCPAL_LOG_INFO, "%s RDMnet Broker Version %s", settings.disc_attributes.dns_manufacturer.c_str(),
+              RDMNET_VERSION_STRING);
     log_->Log(ETCPAL_LOG_INFO, "Broker starting at scope \"%s\", listening on port %d.", disc_.scope().c_str(),
               listen_port_);
 

--- a/src/rdmnet/broker/broker_core.cpp
+++ b/src/rdmnet/broker/broker_core.cpp
@@ -33,12 +33,12 @@
 
 /*************************** Function definitions ****************************/
 
-RDMnet::Broker::Broker(BrokerLog* log, BrokerNotify* notify)
+rdmnet::Broker::Broker(BrokerLog* log, BrokerNotify* notify)
     : core_(std::make_unique<BrokerCore>(log, notify, std::unique_ptr<RdmnetConnInterface>(new RdmnetConnWrapper)))
 {
 }
 
-RDMnet::Broker::~Broker()
+rdmnet::Broker::~Broker()
 {
 }
 
@@ -52,23 +52,23 @@ RDMnet::Broker::~Broker()
 /// \param[in] listen_port Port for the Broker to listen on.
 /// \param[in] listen_addrs Addresses of network interfaces for the Broker to listen on.
 /// \return true (started %Broker successfully) or false (an error occurred starting %Broker).
-bool RDMnet::Broker::Startup(const BrokerSettings& settings, uint16_t listen_port,
+bool rdmnet::Broker::Startup(const BrokerSettings& settings, uint16_t listen_port,
                              std::vector<EtcPalIpAddr>& listen_addrs)
 {
   return core_->Startup(settings, listen_port, listen_addrs);
 }
 
-void RDMnet::Broker::Shutdown()
+void rdmnet::Broker::Shutdown()
 {
   core_->Shutdown();
 }
 
-void RDMnet::Broker::Tick()
+void rdmnet::Broker::Tick()
 {
   core_->Tick();
 }
 
-void RDMnet::Broker::GetSettings(BrokerSettings& settings) const
+void rdmnet::Broker::GetSettings(BrokerSettings& settings) const
 {
   core_->GetSettings(settings);
 }
@@ -78,7 +78,7 @@ void RDMnet::Broker::GetSettings(BrokerSettings& settings) const
 // BrokerCore: Private implementation of Broker functionality.
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-BrokerCore::BrokerCore(RDMnet::BrokerLog* log, RDMnet::BrokerNotify* notify, std::unique_ptr<RdmnetConnInterface> conn)
+BrokerCore::BrokerCore(rdmnet::BrokerLog* log, rdmnet::BrokerNotify* notify, std::unique_ptr<RdmnetConnInterface> conn)
     : RdmnetConnNotify()
     , ListenThreadNotify()
     , ClientServiceThreadNotify()
@@ -101,22 +101,22 @@ BrokerCore::~BrokerCore()
   etcpal_rwlock_destroy(&client_lock_);
 }
 
-bool BrokerCore::Startup(const RDMnet::BrokerSettings& settings, uint16_t listen_port,
+bool BrokerCore::Startup(const rdmnet::BrokerSettings& settings, uint16_t listen_port,
                          const std::vector<EtcPalIpAddr>& listen_addrs)
 {
   if (!started_)
   {
     // Check the settings for validity
     if (ETCPAL_UUID_IS_NULL(&settings.cid) ||
-        (settings.uid_type == RDMnet::BrokerSettings::kStaticUid && !RDMNET_UID_IS_STATIC(&settings.uid)) ||
-        (settings.uid_type == RDMnet::BrokerSettings::kDynamicUid && !RDMNET_UID_IS_DYNAMIC(&settings.uid)))
+        (settings.uid_type == rdmnet::BrokerSettings::kStaticUid && !RDMNET_UID_IS_STATIC(&settings.uid)) ||
+        (settings.uid_type == rdmnet::BrokerSettings::kDynamicUid && !RDMNET_UID_IS_DYNAMIC(&settings.uid)))
     {
       return false;
     }
 
     // Generate IDs if necessary
     my_uid_ = settings.uid;
-    if (settings.uid_type == RDMnet::BrokerSettings::kDynamicUid)
+    if (settings.uid_type == rdmnet::BrokerSettings::kDynamicUid)
     {
       my_uid_.id = 1;
       uid_manager_.SetNextDeviceId(2);
@@ -197,7 +197,7 @@ void BrokerCore::Tick()
 
 // Fills in the current settings the broker is using.  Can be called even after Shutdown. Useful if
 // you want to shutdown & restart the broker for any reason.
-void BrokerCore::GetSettings(RDMnet::BrokerSettings& settings) const
+void BrokerCore::GetSettings(rdmnet::BrokerSettings& settings) const
 {
   settings = settings_;
 }
@@ -491,7 +491,7 @@ void BrokerCore::ProcessConnectRequest(int conn, const ClientConnectMsg* cmsg)
   // auto it =clients_.find(cookie);
   // if(it !=clients_.end())
   //{
-  // RDMnet::SendRedirect(it->second->sock.get(), my_cid,
+  // rdmnet::SendRedirect(it->second->sock.get(), my_cid,
   //    CIPAddr::StringToAddr("192.168.6.12:8888"));
   // MarkSocketForDestruction(cookie, false, 0);
   // return;

--- a/src/rdmnet/broker/broker_core.h
+++ b/src/rdmnet/broker/broker_core.h
@@ -44,7 +44,7 @@ class BrokerCore : public RdmnetConnNotify,
                    public BrokerDiscoveryManagerNotify
 {
 public:
-  BrokerCore(RDMnet::BrokerLog* log, RDMnet::BrokerNotify* notify, std::unique_ptr<RdmnetConnInterface> conn);
+  BrokerCore(rdmnet::BrokerLog* log, rdmnet::BrokerNotify* notify, std::unique_ptr<RdmnetConnInterface> conn);
   virtual ~BrokerCore();
 
   // Some utility functions
@@ -54,14 +54,14 @@ public:
   bool IsValidControllerDestinationUID(const RdmUid& uid) const;
   bool IsValidDeviceDestinationUID(const RdmUid& uid) const;
 
-  RDMnet::BrokerLog* GetLog() { return log_; }
+  rdmnet::BrokerLog* GetLog() { return log_; }
 
-  bool Startup(const RDMnet::BrokerSettings& settings, uint16_t listen_port,
+  bool Startup(const rdmnet::BrokerSettings& settings, uint16_t listen_port,
                const std::vector<EtcPalIpAddr>& listen_addrs);
   void Shutdown();
   void Tick();
 
-  void GetSettings(RDMnet::BrokerSettings& settings) const;
+  void GetSettings(rdmnet::BrokerSettings& settings) const;
 
   // Notification messages from the RDMnet core library
 
@@ -70,12 +70,12 @@ private:
   bool started_{false};
   bool service_registered_{false};
 
-  RDMnet::BrokerLog* log_{nullptr};
+  rdmnet::BrokerLog* log_{nullptr};
   std::unique_ptr<BrokerSocketManager> socket_manager_;
-  RDMnet::BrokerNotify* notify_{nullptr};
+  rdmnet::BrokerNotify* notify_{nullptr};
   std::unique_ptr<RdmnetConnInterface> conn_interface_;
 
-  RDMnet::BrokerSettings settings_;
+  rdmnet::BrokerSettings settings_;
   RdmUid my_uid_{};
 
   std::vector<std::unique_ptr<ListenThread>> listeners_;
@@ -96,7 +96,7 @@ private:
   virtual void RdmnetConnDisconnected(rdmnet_conn_t handle, const RdmnetDisconnectedInfo& disconn_info) override;
   virtual void RdmnetConnMsgReceived(rdmnet_conn_t handle, const RdmnetMessage& msg) override;
 
-  // RDMnet::BrokerSocketManagerNotify messages
+  // rdmnet::BrokerSocketManagerNotify messages
   virtual void SocketDataReceived(rdmnet_conn_t conn_handle, const uint8_t* data, size_t data_size) override;
   virtual void SocketClosed(rdmnet_conn_t conn_handle, bool graceful) override;
 

--- a/src/rdmnet/broker/broker_core.h
+++ b/src/rdmnet/broker/broker_core.h
@@ -30,21 +30,21 @@
 #include "etcpal/socket.h"
 #include "rdmnet/broker.h"
 #include "broker_client.h"
-#include "broker_responder.h"
-#include "broker_threads.h"
 #include "broker_discovery.h"
+#include "broker_responder.h"
+#include "broker_socket_manager.h"
+#include "broker_threads.h"
 #include "broker_uid_manager.h"
 #include "rdmnet_conn_wrapper.h"
 
 class BrokerCore : public RdmnetConnNotify,
-                   public RDMnet::BrokerSocketManagerNotify,
+                   public BrokerSocketManagerNotify,
                    public ListenThreadNotify,
                    public ClientServiceThreadNotify,
                    public BrokerDiscoveryManagerNotify
 {
 public:
-  BrokerCore(RDMnet::BrokerLog* log, RDMnet::BrokerSocketManager* socket_manager, RDMnet::BrokerNotify* notify,
-             std::unique_ptr<RdmnetConnInterface> conn);
+  BrokerCore(RDMnet::BrokerLog* log, RDMnet::BrokerNotify* notify, std::unique_ptr<RdmnetConnInterface> conn);
   virtual ~BrokerCore();
 
   // Some utility functions
@@ -71,7 +71,7 @@ private:
   bool service_registered_{false};
 
   RDMnet::BrokerLog* log_{nullptr};
-  RDMnet::BrokerSocketManager* socket_manager_{nullptr};
+  std::unique_ptr<BrokerSocketManager> socket_manager_;
   RDMnet::BrokerNotify* notify_{nullptr};
   std::unique_ptr<RdmnetConnInterface> conn_interface_;
 

--- a/src/rdmnet/broker/broker_discovery.cpp
+++ b/src/rdmnet/broker/broker_discovery.cpp
@@ -89,7 +89,7 @@ BrokerDiscoveryManager::~BrokerDiscoveryManager()
 {
 }
 
-etcpal_error_t BrokerDiscoveryManager::RegisterBroker(const RDMnet::BrokerDiscoveryAttributes& disc_attributes,
+etcpal_error_t BrokerDiscoveryManager::RegisterBroker(const rdmnet::BrokerDiscoveryAttributes& disc_attributes,
                                                       const EtcPalUuid& local_cid,
                                                       const std::vector<EtcPalIpAddr>& listen_addrs,
                                                       uint16_t listen_port)

--- a/src/rdmnet/broker/broker_discovery.h
+++ b/src/rdmnet/broker/broker_discovery.h
@@ -52,7 +52,7 @@ public:
   virtual ~BrokerDiscoveryManager();
 
   // Registration actions
-  etcpal_error_t RegisterBroker(const RDMnet::BrokerDiscoveryAttributes& disc_attributes, const EtcPalUuid& local_cid,
+  etcpal_error_t RegisterBroker(const rdmnet::BrokerDiscoveryAttributes& disc_attributes, const EtcPalUuid& local_cid,
                                 const std::vector<EtcPalIpAddr>& listen_addrs, uint16_t listen_port);
   void UnregisterBroker();
 

--- a/src/rdmnet/broker/broker_log.cpp
+++ b/src/rdmnet/broker/broker_log.cpp
@@ -27,40 +27,40 @@ static void broker_log_callback(void* context, const EtcPalLogStrings* strings)
 {
   assert(strings);
   assert(strings->human_readable);
-  RDMnet::BrokerLog* bl = static_cast<RDMnet::BrokerLog*>(context);
+  rdmnet::BrokerLog* bl = static_cast<rdmnet::BrokerLog*>(context);
   if (bl)
     bl->LogFromCallback(strings->human_readable);
 }
 
 static void broker_time_callback(void* context, EtcPalLogTimeParams* time)
 {
-  RDMnet::BrokerLog* bl = static_cast<RDMnet::BrokerLog*>(context);
+  rdmnet::BrokerLog* bl = static_cast<rdmnet::BrokerLog*>(context);
   if (bl)
     bl->GetTimeFromCallback(time);
 }
 
 static void log_thread_fn(void* arg)
 {
-  RDMnet::BrokerLog* bl = static_cast<RDMnet::BrokerLog*>(arg);
+  rdmnet::BrokerLog* bl = static_cast<rdmnet::BrokerLog*>(arg);
   if (bl)
     bl->LogThreadRun();
 }
 }  // extern "C"
 
-RDMnet::BrokerLog::BrokerLog() : keep_running_(false)
+rdmnet::BrokerLog::BrokerLog() : keep_running_(false)
 {
   etcpal_signal_create(&signal_);
   etcpal_mutex_create(&lock_);
 }
 
-RDMnet::BrokerLog::~BrokerLog()
+rdmnet::BrokerLog::~BrokerLog()
 {
   Shutdown();
   etcpal_mutex_destroy(&lock_);
   etcpal_signal_destroy(&signal_);
 }
 
-bool RDMnet::BrokerLog::Startup(int log_mask)
+bool rdmnet::BrokerLog::Startup(int log_mask)
 {
   // Set up the log params
   log_params_.action = kEtcPalLogCreateHumanReadableLog;
@@ -73,12 +73,12 @@ bool RDMnet::BrokerLog::Startup(int log_mask)
 
   // Start the log dispatch thread
   keep_running_ = true;
-  EtcPalThreadParams tparams = {ETCPAL_THREAD_DEFAULT_PRIORITY, ETCPAL_THREAD_DEFAULT_STACK, "RDMnet::BrokerLogThread",
+  EtcPalThreadParams tparams = {ETCPAL_THREAD_DEFAULT_PRIORITY, ETCPAL_THREAD_DEFAULT_STACK, "rdmnet::BrokerLogThread",
                                 NULL};
   return etcpal_thread_create(&thread_, &tparams, log_thread_fn, this);
 }
 
-void RDMnet::BrokerLog::Shutdown()
+void rdmnet::BrokerLog::Shutdown()
 {
   if (keep_running_)
   {
@@ -88,7 +88,7 @@ void RDMnet::BrokerLog::Shutdown()
   }
 }
 
-void RDMnet::BrokerLog::Log(int pri, const char* format, ...)
+void rdmnet::BrokerLog::Log(int pri, const char* format, ...)
 {
   va_list args;
   va_start(args, format);
@@ -96,7 +96,7 @@ void RDMnet::BrokerLog::Log(int pri, const char* format, ...)
   va_end(args);
 }
 
-void RDMnet::BrokerLog::LogFromCallback(const std::string& str)
+void rdmnet::BrokerLog::LogFromCallback(const std::string& str)
 {
   {
     etcpal::MutexGuard guard(lock_);
@@ -105,7 +105,7 @@ void RDMnet::BrokerLog::LogFromCallback(const std::string& str)
   etcpal_signal_post(&signal_);
 }
 
-void RDMnet::BrokerLog::LogThreadRun()
+void rdmnet::BrokerLog::LogThreadRun()
 {
   while (keep_running_)
   {

--- a/src/rdmnet/broker/broker_responder.cpp
+++ b/src/rdmnet/broker/broker_responder.cpp
@@ -93,7 +93,7 @@ void BrokerResponder::ProcessRDMMessage(int /*conn*/, const RPTMessageRef& /*msg
 //     RDMnetSocket *psock = GetControllerSocket(cookie);
 //     if (psock)
 //     {
-//       if (!RDMnet::SendRDMMessages(psock, m_settings.cid, resp_end_data,
+//       if (!rdmnet::SendRDMMessages(psock, m_settings.cid, resp_end_data,
 //                                    msgs) &&
 //           m_log)
 //         etcpal_log(m_log, m_log_context, 1, ETCPAL_CAT_APP, ETCPAL_SEV_ERR,

--- a/src/rdmnet/broker/broker_socket_manager.h
+++ b/src/rdmnet/broker/broker_socket_manager.h
@@ -17,15 +17,16 @@
  * https://github.com/ETCLabs/RDMnet
  *****************************************************************************/
 
-/// \file rdmnet/broker/socket_manager.h
-#ifndef _RDMNET_BROKER_SOCKET_MANAGER_H_
-#define _RDMNET_BROKER_SOCKET_MANAGER_H_
+#ifndef _BROKER_SOCKET_MANAGER_H_
+#define _BROKER_SOCKET_MANAGER_H_
 
+#include <memory>
 #include "etcpal/socket.h"
 #include "rdmnet/core/connection.h"
 
-namespace RDMnet
-{
+// The corresponding sources for this file are found in the platform-specific subfolders for each
+// Broker platform.
+
 class BrokerSocketManagerNotify
 {
 public:
@@ -60,6 +61,6 @@ public:
   virtual void RemoveSocket(rdmnet_conn_t conn_handle) = 0;
 };
 
-};  // namespace RDMnet
+std::unique_ptr<BrokerSocketManager> CreateBrokerSocketManager();
 
-#endif  // _RDMNET_BROKER_SOCKET_MANAGER_H_
+#endif  // _BROKER_SOCKET_MANAGER_H_

--- a/src/rdmnet/broker/broker_threads.cpp
+++ b/src/rdmnet/broker/broker_threads.cpp
@@ -39,7 +39,7 @@ static void listen_thread_fn(void* arg)
   }
 }
 
-ListenThread::ListenThread(etcpal_socket_t listen_sock, ListenThreadNotify* pnotify, RDMnet::BrokerLog* log)
+ListenThread::ListenThread(etcpal_socket_t listen_sock, ListenThreadNotify* pnotify, rdmnet::BrokerLog* log)
     : notify_(pnotify), listen_socket_(listen_sock), log_(log)
 {
 }

--- a/src/rdmnet/broker/broker_threads.h
+++ b/src/rdmnet/broker/broker_threads.h
@@ -51,7 +51,7 @@ public:
 class ListenThread
 {
 public:
-  ListenThread(etcpal_socket_t listen_sock, ListenThreadNotify* pnotify, RDMnet::BrokerLog* log);
+  ListenThread(etcpal_socket_t listen_sock, ListenThreadNotify* pnotify, rdmnet::BrokerLog* log);
   virtual ~ListenThread();
 
   // Creates the listening socket and starts the thread.
@@ -70,7 +70,7 @@ protected:
   etcpal_thread_t thread_handle_;
   etcpal_socket_t listen_socket_{ETCPAL_SOCKET_INVALID};
 
-  RDMnet::BrokerLog* log_{nullptr};
+  rdmnet::BrokerLog* log_{nullptr};
 };
 
 /************************************/

--- a/src/rdmnet/broker/linux/linux_socket_manager.cpp
+++ b/src/rdmnet/broker/linux/linux_socket_manager.cpp
@@ -63,7 +63,7 @@ void* SocketWorkerThread(void* arg)
   return reinterpret_cast<void*>(0);
 }
 
-bool LinuxBrokerSocketManager::Startup(RDMnet::BrokerSocketManagerNotify* notify)
+bool LinuxBrokerSocketManager::Startup(BrokerSocketManagerNotify* notify)
 {
   notify_ = notify;
 
@@ -191,4 +191,10 @@ void LinuxBrokerSocketManager::WorkerNotifySocketReadEvent(rdmnet_conn_t conn_ha
       notify_->SocketDataReceived(conn_handle, sock_data->second->recv_buf, recv_result);
     }
   }
+}
+
+// Instantiate a LinuxBrokerSocketManager
+std::unique_ptr<BrokerSocketManager> CreateBrokerSocketManager()
+{
+  return std::make_unique<LinuxBrokerSocketManager>();
 }

--- a/src/rdmnet/broker/linux/linux_socket_manager.h
+++ b/src/rdmnet/broker/linux/linux_socket_manager.h
@@ -17,7 +17,7 @@
  * https://github.com/ETCLabs/RDMnet
  *****************************************************************************/
 
-// Linux override of RDMnet::BrokerSocketManager.
+// Linux override of BrokerSocketManager.
 // Uses epoll, the most efficient and scalable socket management tool available from the Linux API.
 
 #ifndef _LINUX_SOCKET_MANAGER_H_
@@ -29,7 +29,7 @@
 #include <pthread.h>
 
 #include "etcpal/lock.h"
-#include "rdmnet/broker/socket_manager.h"
+#include "broker_socket_manager.h"
 
 // Wrapper around Linux thread functions to increase the testability of this module.
 // TODO on Linux
@@ -75,7 +75,7 @@ struct SocketData
 // performance. Sending on connections is done in the core Broker library through the EtcPal
 // interface. Other miscellaneous Broker socket operations like LLRP are also handled in the core
 // library.
-class LinuxBrokerSocketManager : public RDMnet::BrokerSocketManager
+class LinuxBrokerSocketManager : public BrokerSocketManager
 {
 public:
   LinuxBrokerSocketManager(/* LinuxThreadInterface* thread_interface = new DefaultLinuxThreads */)
@@ -85,8 +85,8 @@ public:
   }
   virtual ~LinuxBrokerSocketManager() { etcpal_rwlock_destroy(&socket_lock_); }
 
-  // RDMnet::BrokerSocketManager interface
-  bool Startup(RDMnet::BrokerSocketManagerNotify* notify) override;
+  // BrokerSocketManager interface
+  bool Startup(BrokerSocketManagerNotify* notify) override;
   bool Shutdown() override;
   bool AddSocket(rdmnet_conn_t conn_handle, etcpal_socket_t socket) override;
   void RemoveSocket(rdmnet_conn_t conn_handle) override;
@@ -110,7 +110,7 @@ private:
   etcpal_rwlock_t socket_lock_;
 
   // The callback instance
-  RDMnet::BrokerSocketManagerNotify* notify_{nullptr};
+  BrokerSocketManagerNotify* notify_{nullptr};
 };
 
 #endif  // _LINUX_SOCKET_MANAGER_H_

--- a/src/rdmnet/broker/macos/macos_socket_manager.cpp
+++ b/src/rdmnet/broker/macos/macos_socket_manager.cpp
@@ -194,3 +194,8 @@ void MacBrokerSocketManager::WorkerNotifySocketReadEvent(rdmnet_conn_t conn_hand
     }
   }
 }
+
+std::unique_ptr<BrokerSocketManager> CreateBrokerSocketManager()
+{
+  return std::make_unique<MacBrokerSocketManager>();
+}

--- a/src/rdmnet/broker/macos/macos_socket_manager.cpp
+++ b/src/rdmnet/broker/macos/macos_socket_manager.cpp
@@ -66,7 +66,7 @@ void* SocketWorkerThread(void* arg)
   return reinterpret_cast<void*>(0);
 }
 
-bool MacBrokerSocketManager::Startup(RDMnet::BrokerSocketManagerNotify* notify)
+bool MacBrokerSocketManager::Startup(BrokerSocketManagerNotify* notify)
 {
   notify_ = notify;
 

--- a/src/rdmnet/broker/macos/macos_socket_manager.h
+++ b/src/rdmnet/broker/macos/macos_socket_manager.h
@@ -17,7 +17,7 @@
  * https://github.com/ETCLabs/RDMnet
  *****************************************************************************/
 
-// macOS override of RDMnet::BrokerSocketManager.
+// macOS override of BrokerSocketManager.
 // Uses epoll, the most efficient and scalable socket management tool available from the Mac API.
 
 #ifndef _MACOS_SOCKET_MANAGER_H_
@@ -50,14 +50,14 @@ struct SocketData
 // performance. Sending on connections is done in the core Broker library through the EtcPal
 // interface. Other miscellaneous Broker socket operations like LLRP are also handled in the core
 // library.
-class MacBrokerSocketManager : public RDMnet::BrokerSocketManager
+class MacBrokerSocketManager : public BrokerSocketManager
 {
 public:
   MacBrokerSocketManager() { etcpal_rwlock_create(&socket_lock_); }
   virtual ~MacBrokerSocketManager() { etcpal_rwlock_destroy(&socket_lock_); }
 
-  // RDMnet::BrokerSocketManager interface
-  bool Startup(RDMnet::BrokerSocketManagerNotify* notify) override;
+  // BrokerSocketManager interface
+  bool Startup(BrokerSocketManagerNotify* notify) override;
   bool Shutdown() override;
   bool AddSocket(rdmnet_conn_t conn_handle, etcpal_socket_t socket) override;
   void RemoveSocket(rdmnet_conn_t conn_handle) override;
@@ -80,7 +80,7 @@ private:
   etcpal_rwlock_t socket_lock_;
 
   // The callback instance
-  RDMnet::BrokerSocketManagerNotify* notify_{nullptr};
+  BrokerSocketManagerNotify* notify_{nullptr};
 };
 
 #endif  // _MACOS_SOCKET_MANAGER_H_

--- a/src/rdmnet/broker/macos/macos_socket_manager.h
+++ b/src/rdmnet/broker/macos/macos_socket_manager.h
@@ -29,7 +29,7 @@
 #include <pthread.h>
 
 #include "etcpal/lock.h"
-#include "rdmnet/broker/socket_manager.h"
+#include "broker_socket_manager.h"
 
 // The set of data allocated per-socket.
 struct SocketData

--- a/src/rdmnet/broker/windows/win_socket_manager.cpp
+++ b/src/rdmnet/broker/windows/win_socket_manager.cpp
@@ -143,7 +143,7 @@ unsigned __stdcall SocketWorkerThread(void* arg)
   return 0;
 }
 
-bool WinBrokerSocketManager::Startup(RDMnet::BrokerSocketManagerNotify* notify)
+bool WinBrokerSocketManager::Startup(BrokerSocketManagerNotify* notify)
 {
   bool ok = true;
   notify_ = notify;
@@ -308,4 +308,9 @@ void WinBrokerSocketManager::WorkerNotifyRecvData(rdmnet_conn_t conn_handle, siz
       notify_->SocketDataReceived(conn_handle, sock_data->second->recv_buf, size);
     }
   }
+}
+
+std::unique_ptr<BrokerSocketManager> CreateBrokerSocketManager()
+{
+  return std::make_unique<WinBrokerSocketManager>();
 }

--- a/src/rdmnet/broker/windows/win_socket_manager.h
+++ b/src/rdmnet/broker/windows/win_socket_manager.h
@@ -17,7 +17,7 @@
  * https://github.com/ETCLabs/RDMnet
  *****************************************************************************/
 
-// Windows override of RDMnet::BrokerSocketManager.
+// Windows override of BrokerSocketManager.
 // Uses Windows I/O completion ports, the most efficient and scalable socket management tool
 // available from the Windows API.
 
@@ -33,7 +33,7 @@
 #include <memory>
 
 #include "etcpal/lock.h"
-#include "rdmnet/broker/socket_manager.h"
+#include "broker_socket_manager.h"
 
 // Wrapper around Windows thread functions to increase the testability of this module.
 class WindowsThreadInterface
@@ -83,7 +83,7 @@ struct SocketData
 // maximum performance. Sending on connections is done in the core Broker library through the EtcPal
 // interface. Other miscellaneous Broker socket operations like LLRP are also handled in the core
 // library.
-class WinBrokerSocketManager : public RDMnet::BrokerSocketManager
+class WinBrokerSocketManager : public BrokerSocketManager
 {
 public:
   WinBrokerSocketManager(WindowsThreadInterface* thread_interface = new DefaultWindowsThreads)
@@ -94,7 +94,7 @@ public:
   virtual ~WinBrokerSocketManager() { etcpal_rwlock_destroy(&socket_lock_); }
 
   // RDMnet::BrokerSocketManager interface
-  bool Startup(RDMnet::BrokerSocketManagerNotify* notify) override;
+  bool Startup(BrokerSocketManagerNotify* notify) override;
   bool Shutdown() override;
   bool AddSocket(rdmnet_conn_t conn_handle, etcpal_socket_t socket) override;
   void RemoveSocket(rdmnet_conn_t conn_handle) override;
@@ -119,7 +119,7 @@ private:
   etcpal_rwlock_t socket_lock_;
 
   // The callback instance
-  RDMnet::BrokerSocketManagerNotify* notify_{nullptr};
+  BrokerSocketManagerNotify* notify_{nullptr};
 };
 
 #endif  // _WIN_SOCKET_MANAGER_H_

--- a/src/rdmnet/broker/windows/win_socket_manager.h
+++ b/src/rdmnet/broker/windows/win_socket_manager.h
@@ -93,7 +93,7 @@ public:
   }
   virtual ~WinBrokerSocketManager() { etcpal_rwlock_destroy(&socket_lock_); }
 
-  // RDMnet::BrokerSocketManager interface
+  // rdmnet::BrokerSocketManager interface
   bool Startup(BrokerSocketManagerNotify* notify) override;
   bool Shutdown() override;
   bool AddSocket(rdmnet_conn_t conn_handle, etcpal_socket_t socket) override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 # Main test module. 
 
-enable_testing()
-
 message(STATUS "Adding GoogleTest dependency...")
 include(AddGoogleTest)
 


### PR DESCRIPTION
BrokerSocketManager should be in the core RDMnet Broker library. I avoided this before because I didn't want platform-specific code in the core libraries. But it's going to need to be in the library so encompassing apps don't need to reimplement it.