### PR TITLE
Fix up the RDMnet device responder data a bit

### DIFF
--- a/examples/device/src/default_responder.c
+++ b/examples/device/src/default_responder.c
@@ -30,7 +30,7 @@
 
 /**************************** Private constants ******************************/
 
-#define NUM_SUPPORTED_PIDS 15
+#define NUM_SUPPORTED_PIDS 12
 static const uint16_t kSupportedPIDList[NUM_SUPPORTED_PIDS] = {
     E120_IDENTIFY_DEVICE,    E120_SUPPORTED_PARAMETERS,     E120_DEVICE_INFO,
     E120_MANUFACTURER_LABEL, E120_DEVICE_MODEL_DESCRIPTION, E120_SOFTWARE_VERSION_LABEL,

--- a/examples/device/src/default_responder.c
+++ b/examples/device/src/default_responder.c
@@ -42,7 +42,7 @@ static const uint16_t kSupportedPIDList[NUM_SUPPORTED_PIDS] = {
 static const uint8_t kDeviceInfo[] = {
     0x01, 0x00, /* RDM Protocol version */
     0xe1, 0x33, /* Device Model ID */
-    0xe1, 0x33, /* Product Category */
+    0x71, 0x01, /* Product Category */
 
     /* Software Version ID */
     RDMNET_VERSION_MAJOR, RDMNET_VERSION_MINOR,


### PR DESCRIPTION
This sets the product category to PRODUCT_CATEGORY_TEST_EQUIPMENT rather than a manufacturer specific category which coincidentally happens to match the device model ID!

It also fixes the returned data in SUPPORTED_PARAMETERS.