### PR TITLE
Include initial_data_.netints in the broker settings

### DIFF
--- a/examples/broker/src/broker_shell.cpp
+++ b/examples/broker/src/broker_shell.cpp
@@ -76,11 +76,7 @@ int BrokerShell::Run(etcpal::Logger& log)
   broker_settings.dns.manufacturer = "ETC";
   broker_settings.dns.model = "RDMnet Broker Example App";
   broker_settings.listen_port = initial_data_.port;
-
-  if (!initial_data_.netints.empty())
-  {
-    broker_settings.listen_interfaces = initial_data_.netints;
-  }
+  broker_settings.listen_interfaces = initial_data_.netints;
 
   rdmnet::Broker broker;
 

--- a/examples/broker/src/broker_shell.cpp
+++ b/examples/broker/src/broker_shell.cpp
@@ -77,6 +77,11 @@ int BrokerShell::Run(etcpal::Logger& log)
   broker_settings.dns.model = "RDMnet Broker Example App";
   broker_settings.listen_port = initial_data_.port;
 
+  if (!initial_data_.netints.empty())
+  {
+    broker_settings.listen_interfaces = initial_data_.netints;
+  }
+
   rdmnet::Broker broker;
 
   res = broker.Startup(broker_settings, log_, this);


### PR DESCRIPTION
I discovered that using the --ifaces argument in the broker example was not doing anything. I realized it was not being passed into the broker arguments, so I went ahead and added this. I briefly tested with the broker on my 2nd interface, and a controller and device, and I'm able to identify the device from the controller and everything looks normal so far.