### PR TITLE
Have clients retry the connection if they fail due to "duplicate UID"

### DIFF
--- a/include/rdmnet/client.h
+++ b/include/rdmnet/client.h
@@ -183,7 +183,7 @@ typedef struct RdmnetClientConnectFailedInfo
    * that the connection failed for a reason that usually must be corrected by a user or
    * application developer. Some possible reasons for this to be false include:
    * - The wrong scope was specified for a statically-configured broker
-   * - A static UID was given that was invalid or duplicate with another UID in the system
+   * - A static UID was given that was invalid
    */
   bool will_retry;
 } RdmnetClientConnectFailedInfo;

--- a/include/rdmnet/cpp/client.h
+++ b/include/rdmnet/cpp/client.h
@@ -280,7 +280,7 @@ constexpr rdmnet_connect_status_t ClientConnectFailedInfo::rdmnet_reason() const
 /// that the connection failed for a reason that usually must be corrected by a user or application
 /// developer. Some possible reasons for this to be false include:
 /// - The wrong scope was specified for a statically-configured broker
-/// - A static UID was given that was invalid or duplicate with another UID in the system
+/// - A static UID was given that was invalid
 constexpr bool ClientConnectFailedInfo::will_retry() const noexcept
 {
   return info_.will_retry;

--- a/src/rdmnet/core/client.c
+++ b/src/rdmnet/core/client.c
@@ -1586,7 +1586,7 @@ bool connect_failed_will_retry(rdmnet_connect_fail_event_t event, rdmnet_connect
     case kRdmnetConnectFailSocketFailure:
       return false;
     case kRdmnetConnectFailRejected:
-      return (status == kRdmnetConnectCapacityExceeded);
+      return ((status == kRdmnetConnectCapacityExceeded) || (status == kRdmnetConnectDuplicateUid));
     case kRdmnetConnectFailTcpLevel:
     case kRdmnetConnectFailNoReply:
     default:

--- a/tests/unit/core/client/test_rpt_client_connection_handling.cpp
+++ b/tests/unit/core/client/test_rpt_client_connection_handling.cpp
@@ -406,13 +406,13 @@ TEST_F(TestDynamicRptClientConnectionHandling, ScopeStillExistsOnFatalConnectFai
 
   RCConnectFailedInfo failed_info{};
   failed_info.event = kRdmnetConnectFailRejected;
-  failed_info.rdmnet_reason = kRdmnetConnectDuplicateUid;
+  failed_info.rdmnet_reason = kRdmnetConnectInvalidUid;
   conns_registered[0]->callbacks.connect_failed(conns_registered[0], &failed_info);
 
   EXPECT_EQ(rc_client_connect_failed_fake.call_count, 1u);
   EXPECT_FALSE(client_connect_failed_info.will_retry);
   EXPECT_EQ(client_connect_failed_info.event, kRdmnetConnectFailRejected);
-  EXPECT_EQ(client_connect_failed_info.rdmnet_reason, kRdmnetConnectDuplicateUid);
+  EXPECT_EQ(client_connect_failed_info.rdmnet_reason, kRdmnetConnectInvalidUid);
 
   EXPECT_EQ(rc_conn_connect_fake.call_count, 0u);
   EXPECT_EQ(rc_conn_unregister_fake.call_count, 0u);


### PR DESCRIPTION
When a client reboots, and tries to reconnect to the broker, the old connection may still be there, in which case the new connection may fail due to the "duplicate UID" error. In this case, the client should retry, since it will most likely succeed when it does, as the old connection will have been cleaned up. The downside to this is that if it is a user-fixable configuration error of static UIDs, then this will just retry indefinitely.