### PR TITLE
Unit test new MarkClientForDestruction behavior

### DIFF
--- a/tests/unit/broker/test_broker_core_connect_handling.cpp
+++ b/tests/unit/broker/test_broker_core_connect_handling.cpp
@@ -125,9 +125,9 @@ TEST_F(TestBrokerCoreConnectHandling, HandlesRemoveUidOnDisconnect)
   RdmnetMessage        disconnect_msg = testmsgs::ClientDisconnect(client_cid, kRdmnetDisconnectShutdown);
 
   mocks_.broker_callbacks->HandleSocketMessageReceived(conn_handle, connect_msg);
-  EXPECT_TRUE(broker_.IsValidControllerDestinationUID(rdm::Uid(0x6574, 0x00000001).get()));
+  EXPECT_TRUE(broker_.IsValidControllerDestinationUID(rdm::Uid(0xe574, 0x00000002).get()));
 
   // Use IsValidControllerDestinationUID to verify that RemoveUid gets called immediately.
   mocks_.broker_callbacks->HandleSocketMessageReceived(conn_handle, disconnect_msg);
-  EXPECT_FALSE(broker_.IsValidControllerDestinationUID(rdm::Uid(0x6574, 0x00000001).get()));
+  EXPECT_FALSE(broker_.IsValidControllerDestinationUID(rdm::Uid(0xe574, 0x00000002).get()));
 }

--- a/tests/unit/broker/test_broker_messages.h
+++ b/tests/unit/broker/test_broker_messages.h
@@ -63,6 +63,21 @@ inline RdmnetMessage ClientConnect(const etcpal::Uuid& cid, std::string scope = 
   return connect_msg;
 }
 
+inline RdmnetMessage ClientDisconnect(const etcpal::Uuid& cid, rdmnet_disconnect_reason_t disconnect_reason)
+{
+  RdmnetMessage disconnect_msg;
+  disconnect_msg.vector = ACN_VECTOR_ROOT_BROKER;
+  disconnect_msg.sender_cid = cid.get();
+
+  BrokerMessage* broker_msg = RDMNET_GET_BROKER_MSG(&disconnect_msg);
+  broker_msg->vector = VECTOR_BROKER_DISCONNECT;
+
+  BrokerDisconnectMsg* client_disconnect = BROKER_GET_DISCONNECT_MSG(broker_msg);
+  client_disconnect->disconnect_reason = disconnect_reason;
+
+  return disconnect_msg;
+}
+
 inline RdmnetMessage Null(const etcpal::Uuid& cid)
 {
   RdmnetMessage null_msg;


### PR DESCRIPTION
MarkLockedClientForDestruction was recently changed to immediately remove the UID and send a clients removed message. I forgot to write a unit test for this. I wrote one to test the UID being removed. Holding off on writing one for clients removed since we have plans to change client list update sending.