### PR TITLE
Remove wrong `broker_handle` assertion that bricks discovery on Linux

### DIFF
--- a/src/rdmnet/disc/avahi/rdmnet_disc_avahi.c
+++ b/src/rdmnet/disc/avahi/rdmnet_disc_avahi.c
@@ -177,7 +177,7 @@ static void browse_callback(AvahiServiceBrowser*                    b,
                             void*                                   userdata)
 {
   RdmnetScopeMonitorRef* ref = (RdmnetScopeMonitorRef*)userdata;
-  if (!RDMNET_ASSERT_VERIFY(ref) || !RDMNET_ASSERT_VERIFY(ref->broker_handle))
+  if (!RDMNET_ASSERT_VERIFY(ref))
     return;
 
   if (event == AVAHI_BROWSER_FAILURE)


### PR DESCRIPTION
Hi, I am currently beginning work on an RDMnet controller. My first step was trying to build every target of your RDMnet repo under Linux.

I was able to build all examples, including the GUI one. When it came to running, the *broker* works flawlessly, but for *device* or *controller*, the assertion in line 180 of `rdmnet_disc_avahi.c` that was [introduced last year](https://github.com/ETCLabs/RDMnet/commit/b9185be1035461e4bb974c04dba2c7c2923a4082#diff-83fd7ec9935c4ce7b5dd1061bad44e190cde8bdc052b84a61a54456c7fad2bde) brings the programs to a halt almost immediately after starting them, as `broker_handle` is NULL there.

The assertion states that there must be a `broker_handle` already when we receive the `browse_callback` from Avahi. This seems to me to not make much sense, as `avahi_service_browser_new` is called with `broker_handle` being NULL, and Avahi won't change the `userdata` it got. Comparing to `rdmnet_disc_bonjour.c`, there is a similar assertion in line 284, but without checking for a valid `broker_handle`.

If I remove the assertion, like this PR does, `controller` and `device` seem to work fine. If you don't accept this PR, please tell me what I did wrong.

Thanks,
Mitja