### PR TITLE
Bump libgadget release version in cmake files

### DIFF
--- a/cmake/AddLibGadget.cmake
+++ b/cmake/AddLibGadget.cmake
@@ -1,6 +1,6 @@
 message(STATUS "Adding libGadget for Fakeway example...")
 
-set(LIBGADGET_FETCHCONTENT_VERSION 2.1.0.1)
+set(LIBGADGET_FETCHCONTENT_VERSION 3.0.0.1)
 
 include(FetchContent)
 FetchContent_Declare(

--- a/examples/fakeway/CMakeLists.txt
+++ b/examples/fakeway/CMakeLists.txt
@@ -4,7 +4,7 @@ else()
   list(APPEND CMAKE_PREFIX_PATH ${libgadget_SOURCE_DIR}/x64)
 endif()
 
-find_package(GadgetDLL 2.1.0 REQUIRED)
+find_package(GadgetDLL 3.0.0 REQUIRED)
 
 set(FAKEWAY_TARGET rdmnet_gateway_example)
 add_executable(${FAKEWAY_TARGET}


### PR DESCRIPTION
Assuming you build against the MSVC 2017 toolchain to match the DLL, libgadget v3.0.0.1 is a drop-in replacement and adds support for Gadget 2 CPU2 (iMXRT) to the Fakeway example.

This is a short and sweet PR to bump the version that CMake pulls in.